### PR TITLE
dirの修正

### DIFF
--- a/rfriends_wsl.sh
+++ b/rfriends_wsl.sh
@@ -17,7 +17,7 @@ echo rfriends3 for wsl $ver
 echo
 # -----------------------------------------
 user=`whoami`
-dir=.
+dir=rfriends_wsl
 userstr="s/rfriendsuser/${user}/g"
 # -----------------------------------------
 ar=`dpkg --print-architecture`


### PR DESCRIPTION
dir=. となっているため、15-fastcgi-php.conf.skel とlighttpd.conf.skelを見つけられないため、lighttpdが起動しない